### PR TITLE
Change “parent class” to “wrapper class”

### DIFF
--- a/kotlin-code-style.md
+++ b/kotlin-code-style.md
@@ -16,7 +16,7 @@ class Person(val firstName: String, val lastName: String, var age: Int) {
 ```
 ## Companion object
 
-It should be place at the beginning of its parent class :
+It should be place at the beginning of its wrapper class :
 
 ```kotlin
 class Person(val firstName: String, val lastName: String, var age: Int) {


### PR DESCRIPTION
Since the Person class is not the parent, inheritance-wise (i.e., the companion object doesn't extend Person), it's more correct to call it a wrapper class. It's an “inner object”, so to speak.
